### PR TITLE
Option -e extends FUZZ keyword

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -10,7 +10,7 @@ select choice in "${choices[@]}"; do
 			printf "\nDirectory Bruteforcing"
 			printf "\n\nEnter the url for Directory Bruteforcing: "
 			read input1
-			ffuf -mc all -c -H "X-Forwarded-For: 127.0.0.1" -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0" -u "$input1/FUZZ" -w wordlist/dicc.txt -D -e js,php,bak,txt,asp,aspx,jsp,html,zip,jar,sql,json,old,gz,shtml,log,swp,yaml,yml,config,save,rsa,ppk -ac -o result_dir.tmp
+			ffuf -mc all -c -H "X-Forwarded-For: 127.0.0.1" -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0" -u "$input1/FUZZ" -w wordlist/dicc.txt -D -e .js,.php,.bak,.txt,.asp,.aspx,.jsp,.html,.zip,.jar,.sql,.json,.old,.gz,.shtml,.log,.swp,.yaml,.yml,.config,.save,.rsa,.ppk -ac -o result_dir.tmp
 			cat result_dir.tmp | jq '[.results[]|{status: .status, length: .length, url: .url}]' | grep -oP "status\":\s(\d{3})|length\":\s(\d{1,7})|url\":\s\"(http[s]?:\/\/.*?)\"" | paste -d' ' - - - | awk '{print $2" "$4" "$6}' | sed 's/\"//g' > result_dir.txt
 			printf "\nDone. Result is stored in result_dir.txt\n"
 			break
@@ -47,7 +47,7 @@ select choice in "${choices[@]}"; do
                 "Beast Mode")
                         echo "Beast Mode ON"
                         mkdir ffuf
-                        xargs -P10 -I {} sh -c 'url="{}"; ffuf -s -mc all -c -H "X-Forwarded-For: 127.0.0.1" -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0" -u "{}/FUZZ" -w wordlist/dicc.txt -t 50 -D -e js,php,bak,txt,asp,aspx,jsp,html,zip,jar,sql,json,old,gz,shtml,log,swp,yaml,yml,config,save,rsa,ppk -ac -se -o ffuf/${url##*/}-${url%%:*}.json' < alive.txt
+                        xargs -P10 -I {} sh -c 'url="{}"; ffuf -s -mc all -c -H "X-Forwarded-For: 127.0.0.1" -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0" -u "{}/FUZZ" -w wordlist/dicc.txt -t 50 -D -e .js,.php,.bak,.txt,.asp,.aspx,.jsp,.html,.zip,.jar,.sql,.json,.old,.gz,.shtml,.log,.swp,.yaml,.yml,.config,.save,.rsa,.ppk -ac -se -o ffuf/${url##*/}-${url%%:*}.json' < alive.txt
                         cat ffuf/* | jq '[.results[]|{status: .status, length: .length, url: .url}]' | grep -oP "status\":\s(\d{3})|length\":\s(\d{1,7})|url\":\s\"(http[s]?:\/\/.*?)\"" | paste -d' ' - - - | awk '{print $2" "$4" "$6}' | sed 's/\"//g' > result_beast.txt
                         rm ffuf -r
 			printf "\nDone. Result is stored in result_beast.txt\n"


### PR DESCRIPTION
As ffuf docs say -e options just appends/extends FUZZ,
so we need to put dot(.) so that extensions behave like ext.

Discuss with @joohoi on this too before making fix. 